### PR TITLE
Run Circle CI builds for new projects.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 npm-debug.log
 tmp/*
+.idea/

--- a/api/src/circle.js
+++ b/api/src/circle.js
@@ -1,0 +1,42 @@
+if (!process.env.CIRCLE_TOKEN) {
+	throw "process.env.CIRCLE_TOKEN required";
+}
+
+const baseUrl = 'https://circleci.com/api/v1.1';
+const request = require('request');
+
+function fetch(method, path, payload, callback) {
+	request({
+		url: baseUrl + path,
+		qs: {'circle-token': process.env.CIRCLE_TOKEN},
+		method: method,
+		headers: {'Content-Type': 'application/json'},
+		json: payload
+	}, callback);
+}
+
+function registerKeys(name, callback) {
+	const payload = {
+		type: 'deploy-key'
+	};
+
+	fetch('POST', `/project/github/utilitywarehouse/${name}/checkout-key`, payload, callback);
+}
+
+function follow(name, callback) {
+	fetch('POST', `/project/github/utilitywarehouse/${name}/follow`, null, callback);
+}
+
+function build(name, callback) {
+	fetch('POST', `/project/github/utilitywarehouse/${name}/tree/master`, null, callback);
+}
+
+module.exports.setup = (name, callback) => {
+	registerKeys(name, () => {
+		follow(name, () => {
+			build(name, () => {
+				callback();
+			});
+		});
+	});
+};

--- a/api/src/github.js
+++ b/api/src/github.js
@@ -3,6 +3,7 @@ if (!process.env.GITHUB_TOKEN) {
 }
 
 const GitHubApi = require("github");
+const SimpleGit = require("simple-git");
 
 const github = new GitHubApi({
     debug: false,
@@ -43,29 +44,13 @@ github.repos.get({owner: 'utilitywarehouse', repo: name})
 })
 }
 
-var Git = require("nodegit");
-
-module.exports.init = function(path, origin, callback) {
-	Git.Repository.init(path, 0).then((repository) => {
-
-		Git.Remote.setUrl(repository, 'origin', origin);
-
-		return callback();
-	}).catch((err) => {
-		return callback(err)
-	});
-}
-
-module.exports.commit = function(root) {
-
-	Git.Index.open(index_path).then(function(index) {
-
-		index.addByPath(root).then((res) => {
-			console.log(res)
-		}).catch((err) => {
-			console.error(res);
-		})
-
-	});
-
+module.exports.push = function(path, origin, callback) {
+	SimpleGit(path)
+		.init()
+		.add('./*')
+		.commit('Initial commit')
+		.addRemote('origin', origin)
+		.push('origin', 'master', () => {
+			callback()
+		});
 }

--- a/lazy-api.js
+++ b/lazy-api.js
@@ -6,15 +6,16 @@ const path = require('path');
 const files = require('./api/src/files');
 const interaction = require('./api/src/interaction');
 const github = require('./api/src/github');
+const circle = require('./api/src/circle');
 
 /**
  *  program execution
  */
 program
-  .version('0.0.1')
-  .arguments('<name> [directory]')
+	.version('0.0.1')
+	.arguments('<name> [directory]')
 	.usage('lazy api <name>')
-  .action(function(name, directory) {
+	.action(function(name, directory) {
 
 		if (!directory) {
 			directory = name;
@@ -51,23 +52,15 @@ program
 			output.write('Creating GitHub repository');
 
 			github.create(name, (repoUrl) => {
-					output.write('Initialising local repository');
+				output.write('Preparing local repository');
 
-					github.init(projectPath, repoUrl, (err) => {
+				github.push(projectPath, repoUrl, () => {
+					output.write('repository prepared');
+					output.write('Registering keys with Circle CI');
 
-						if (err) {
-							output.die(err);
-						}
-
-						output.break();
-						output.ok('repository created');
-
-						output.write('Creating intial commit');
-
-						github.commit(projectPath);
-
-					});
+					circle.setup(name, () => {});
+				});
 			});
 		});
-  })
-  .parse(process.argv);
+	})
+	.parse(process.argv);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "github": "^6.0.4",
     "inquirer": "^1.2.2",
     "mkdir-recursive": "^0.2.3",
-    "nodegit": "^0.16.0",
+    "request": "^2.78.0",
+    "simple-git": "^1.62.0",
     "ucfirst": "^1.0.0"
   },
   "lazy": {


### PR DESCRIPTION
@michael-donat 

Replaces nodegit for simple-git + adds Circle CI building. The `circleci` module doesn't cover what we needed, so I had to move to making the requests manually; nothing too complicated though. Not handling errors from that though, will need to adjust. "Happy path" is working though.